### PR TITLE
chore: use npm 'ci' instead of 'install'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install
+      - run: npm ci
       - run: cp .env.local.sample .env.local
       - run: npm run build
         continue-on-error: FALSE


### PR DESCRIPTION
The repo has a package-lock.json file. `npm ci` will be faster and will ensure consistency across systems.