### PR TITLE
Add key prop to sidebar items

### DIFF
--- a/src/components/DocsSidebar.tsx
+++ b/src/components/DocsSidebar.tsx
@@ -18,7 +18,7 @@ export function DocsSidebar(props: DocsSidebarProps) {
       const { label, children } = item;
 
       return (
-        <>
+        <div key={item.id}>
           <Typography
             variant="body1"
             component="h3"
@@ -29,7 +29,7 @@ export function DocsSidebar(props: DocsSidebarProps) {
             <List>
               {children.map((child: any) => {
                 return (
-                  <ListItem disablePadding>
+                  <ListItem key={child.id} disablePadding>
                     <Link
                       sx={{
                         '&:hover': {
@@ -50,7 +50,7 @@ export function DocsSidebar(props: DocsSidebarProps) {
               })}
             </List>
           ) : null}
-        </>
+        </div>
       );
     });
   }


### PR DESCRIPTION
## Testing

Observe that no warnings about missing key props are present: https://h3wv8h2tnqt87kyiwlfvfnji5.js.wpenginepowered.com/reference/example-function