### PR TITLE
Added first:100 to return all the sidebar links

### DIFF
--- a/src/wp-templates/SingleFaustExplanation.tsx
+++ b/src/wp-templates/SingleFaustExplanation.tsx
@@ -120,7 +120,7 @@ Component.query = gql(`
         ...SecondaryMenuItemsFragment
       }
     }
-    docsSidebarMenuItems: menuItems(where: {location: DOCS_SIDEBAR}) {
+    docsSidebarMenuItems: menuItems(first: 100, where: {location: DOCS_SIDEBAR}) {
       nodes {
         ...DocsSidebarMenuItemsFragment
       }

--- a/src/wp-templates/SingleFaustHowToGuide.tsx
+++ b/src/wp-templates/SingleFaustHowToGuide.tsx
@@ -120,7 +120,7 @@ Component.query = gql(`
         ...SecondaryMenuItemsFragment
       }
     }
-    docsSidebarMenuItems: menuItems(where: {location: DOCS_SIDEBAR}) {
+    docsSidebarMenuItems: menuItems(first: 100, where: {location: DOCS_SIDEBAR}) {
       nodes {
         ...DocsSidebarMenuItemsFragment
       }

--- a/src/wp-templates/SingleFaustReference.tsx
+++ b/src/wp-templates/SingleFaustReference.tsx
@@ -120,7 +120,7 @@ Component.query = gql(`
         ...SecondaryMenuItemsFragment
       }
     }
-    docsSidebarMenuItems: menuItems(where: {location: DOCS_SIDEBAR}) {
+    docsSidebarMenuItems: menuItems(first: 100, where: {location: DOCS_SIDEBAR}) {
       nodes {
         ...DocsSidebarMenuItemsFragment
       }

--- a/src/wp-templates/SingleFaustTutorial.tsx
+++ b/src/wp-templates/SingleFaustTutorial.tsx
@@ -120,7 +120,7 @@ Component.query = gql(`
         ...SecondaryMenuItemsFragment
       }
     }
-    docsSidebarMenuItems: menuItems(where: {location: DOCS_SIDEBAR}) {
+    docsSidebarMenuItems: menuItems(first: 100, where: {location: DOCS_SIDEBAR}) {
       nodes {
         ...DocsSidebarMenuItemsFragment
       }


### PR DESCRIPTION
Description:
[MERL-1000](https://wpengine.atlassian.net/browse/MERL-1000) - Fixing truncated docs sidebar issue for Faust v2

The following changes have been made:
1. Added "first: 100" to the DocsSideBarMenuItemsFragment query in order to return more than 10 menu items.

[MERL-1000]: https://wpengine.atlassian.net/browse/MERL-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ