### PR TITLE
MERL-1015 Styling of NOTEs and Inline block elements

### DIFF
--- a/src/styles/_blocks.scss
+++ b/src/styles/_blocks.scss
@@ -11,3 +11,11 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/block-library/src/style.scss';
 @import '@wordpress/block-library/src/theme.scss';
+
+// Block Customizations
+@import 'wp-block-code';
+p.has-background {
+	border-radius: 0.5rem;
+	margin-left: auto;
+    margin-right: auto;
+}

--- a/src/styles/_wp-block-code.scss
+++ b/src/styles/_wp-block-code.scss
@@ -13,3 +13,15 @@
   	overflow-x: auto !important;
   }
 }
+
+:not(.wp-block-code) > p > code {
+    background-color: var(--wp--preset--color--contrast);
+    color: var(--wp--preset--color--base);
+    font-size: var(--wp--preset--font-size--small);
+	font-family: var(--wp--preset--font-family--monospace);
+    padding: 5px 8px;
+	overflow-wrap: normal;
+	overflow-x: scroll;
+	tab-size: 4;
+	white-space: pre !important;
+}


### PR DESCRIPTION
# Description

* Style Paragraph with background color
* Style inline code blocks.

# Screenshots

<img width="1083" alt="Screenshot 2023-06-27 at 14 50 44" src="https://github.com/wpengine/faustjs.org/assets/328805/149ab737-22fe-47c6-a0bd-6a1ee52e16b5">
