### PR TITLE
Include redirects from WordPress plugin settings

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,26 @@ module.exports = withFaust({
   async redirects() {
     return [
       {
+        source: '/docs/next/guides/fetching-data',
+        destination: '/guide/how-to-use-apollo-in-faust',
+        permanent: true,
+      },
+      {
+        source: '/docs/next/guides/auth',
+        destination: '/guide/how-to-handle-authentication',
+        permanent: true,
+      },
+      {
+        source: '/docs/tutorial/dev-env-setup',
+        destination: '/guide/how-to-use-the-faust-example-project',
+        permanent: true,
+      },
+      {
+        source: '/docs/next/getting-started',
+        destination: '/tutorial/get-started-with-faust',
+        permanent: true,
+      },
+      {
         source: '/docs/reference/useBlocksTheme',
         destination: '/reference/useblockstheme',
         permanent: true,


### PR DESCRIPTION
## Testing

The links below should successfully redirect

- https://hawonf553vw3yg2yl3d91horg.js.wpenginepowered.com/docs/next/guides/fetching-data
- https://hawonf553vw3yg2yl3d91horg.js.wpenginepowered.com/docs/next/guides/auth
- https://hawonf553vw3yg2yl3d91horg.js.wpenginepowered.com/docs/tutorial/dev-env-setup
- https://hawonf553vw3yg2yl3d91horg.js.wpenginepowered.com/docs/next/getting-started

## Screenshots

<img width="701" alt="Screenshot 2023-06-29 at 4 34 13 PM" src="https://github.com/wpengine/faustjs.org/assets/6676674/cbbcb1d5-5f1c-420d-bafe-798a89c4cc4f">
