### PR TITLE
Add icons to external links in header and footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,7 +8,6 @@ import {
   ListItem,
   Stack,
 } from '@mui/material';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { FooterMenuItemsFragmentFragment } from '__generated__/graphql';
 import { gql } from '__generated__';
 import { Link } from './Link';
@@ -19,6 +18,7 @@ type FooterProps = {
   footer3MenuItems: FooterMenuItemsFragmentFragment[] | any;
   footer4MenuItems: FooterMenuItemsFragmentFragment[] | any;
 };
+
 export function Footer({
   footer1MenuItems,
   footer2MenuItems,
@@ -58,15 +58,6 @@ export function Footer({
                     },
                   }}>
                   {item.label}
-                  {(item.uri.slice(0, 6) === 'https:' ||
-                    item.uri.slice(0, 5) === 'http:') && (
-                    <OpenInNewIcon
-                      sx={{
-                        fontSize: '0.8rem',
-                        color: 'var(--wp--preset--color--base)',
-                      }}
-                    />
-                  )}
                 </Link>
               </ListItem>
             ))}

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,7 +1,37 @@
 import React from 'react';
-import { LinkProps, Link as MuiLink } from '@mui/material';
+import { Box, LinkProps, Link as MuiLink } from '@mui/material';
 import NextLink from 'next/link';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+
+function isExternalURL(urlInput: string | URL) {
+  try {
+    const url = new URL(urlInput);
+    if (url.origin !== 'https://faustjs.org') {
+      return true;
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
 
 export function Link(props: LinkProps<'a'>) {
-  return <MuiLink component={NextLink} {...props} />;
+  const { children } = props;
+  const { href } = props;
+  return (
+    <MuiLink component={NextLink} {...props}>
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        {children}
+        {isExternalURL(href) && (
+          <OpenInNewIcon
+            sx={{
+              fontSize: '1rem',
+              color: 'inherit',
+              marginLeft: '0.2rem',
+            }}
+          />
+        )}
+      </Box>
+    </MuiLink>
+  );
 }

--- a/src/components/TopHeaderAppBar.tsx
+++ b/src/components/TopHeaderAppBar.tsx
@@ -132,15 +132,6 @@ export function TopHeaderAppBar({
                   },
                 }}>
                 {item.label}
-                {(item.uri.slice(0, 6) === 'https:' ||
-                  item.uri.slice(0, 5) === 'http:') && (
-                  <OpenInNewIcon
-                    sx={{
-                      fontSize: '0.8rem',
-                      color: 'var(--wp--preset--color--contrast)',
-                    }}
-                  />
-                )}
               </Link>
             ))}
           </Box>


### PR DESCRIPTION
[MERL-1049](https://wpengine.atlassian.net/browse/MERL-1049): Add external link icon to links that open to external sites

- Used MUI OpenInNewIcon component to add external link icon to primary header and footer links that start with "https:"
  - Every link in the footer except the Privacy Policy is external (though some don't open in new tab)
- Didn't include the external icon for the secondary header containing the social media icons

[MERL-1049]: https://wpengine.atlassian.net/browse/MERL-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ