### PR TITLE
Fix blog redirect loop

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -237,8 +237,8 @@ module.exports = withFaust({
         permanent: true,
       },
       {
-        source: '/blog/:slug*',
-        destination: '/:slug*',
+        source: '/blog/:slug',
+        destination: '/:slug',
         permanent: true,
       },
     ];


### PR DESCRIPTION
These changes fix the redirect loop that occurs when directly loading /blog.

## Testing

1. Observe that directly visiting [/blog](https://hb80avekg7wo4bodsja029gbs.js.wpenginepowered.com/blog) within the Atlas Preview Environment properly loads.