### PR TITLE
Added external icon as part of Link component

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,7 +1,43 @@
 import React from 'react';
-import { LinkProps, Link as MuiLink } from '@mui/material';
+import { Box, LinkProps, Link as MuiLink } from '@mui/material';
 import NextLink from 'next/link';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+
+function isExternalURL(urlInput: string | URL) {
+  try {
+    const url = new URL(urlInput);
+    if (url.origin !== 'https://faustjs.org') {
+      return true;
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
 
 export function Link(props: LinkProps<'a'>) {
-  return <MuiLink component={NextLink} {...props} />;
+  const { children } = props;
+  const { href } = props;
+  const { className } = props;
+
+  return (
+    <MuiLink component={NextLink} {...props}>
+      {className !== 'TopHeaderAppBar_social-navigation-link__KFeb1' ? (
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          {children}
+          {isExternalURL(href) && (
+            <OpenInNewIcon
+              sx={{
+                fontSize: '1rem',
+                color: 'inherit',
+                marginLeft: '0.2rem',
+              }}
+            />
+          )}
+        </Box>
+      ) : (
+        children
+      )}
+    </MuiLink>
+  );
 }


### PR DESCRIPTION
Related PR that was closed: https://github.com/wpengine/faustjs.org/pull/58

[MERL-1049](https://wpengine.atlassian.net/browse/MERL-1049): Add external link icon to links that open to external sites

- Used MUI OpenInNewIcon component to add external link icon as an attribute of the Link component
- Didn't include the external icon for the secondary header containing the social media icons

Thanks to @josephfusco for the solution idea!

[MERL-1049]: https://wpengine.atlassian.net/browse/MERL-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ