### PR TITLE
Merl 1042 sidebar table of contents

### DIFF
--- a/src/components/SidebarLayout.tsx
+++ b/src/components/SidebarLayout.tsx
@@ -4,10 +4,13 @@ import { DocsSidebarMenuItemsFragmentFragment } from '__generated__/graphql';
 import ListIcon from '@mui/icons-material/List';
 import { DocsSidebar } from './DocsSidebar';
 import { OverlayDialog } from './OverlayDialog';
+import { TableOfContents } from './TableOfContents';
+import { HeaderItem } from '../types';
 
 export interface SidebarLayoutProps {
   menuItems: DocsSidebarMenuItemsFragmentFragment[];
   children: React.ReactNode;
+  tableOfContents?: HeaderItem[];
 }
 const fabStyle = {
   position: 'fixed',
@@ -16,7 +19,7 @@ const fabStyle = {
   display: { xs: 'block', md: 'none' },
 };
 export function SidebarLayout(props: SidebarLayoutProps) {
-  const { menuItems, children } = props;
+  const { menuItems, children, tableOfContents } = props;
   const [open, setOpen] = React.useState(false);
 
   const handleSideBarOpen = () => {
@@ -28,12 +31,12 @@ export function SidebarLayout(props: SidebarLayoutProps) {
   };
   return (
     <Grid container spacing={2} sx={{ display: 'flex', flexDirection: 'row' }}>
-      <Grid item xs={12} md={4}>
+      <Grid item xs={12} md={3}>
         <Box sx={{ display: { md: 'block', xs: 'none' } }}>
           <DocsSidebar menuItems={menuItems} />
         </Box>
       </Grid>
-      <Grid item xs={12} md={8}>
+      <Grid item xs={12} md={7}>
         {children}
         <Fab
           color="secondary"
@@ -52,6 +55,13 @@ export function SidebarLayout(props: SidebarLayoutProps) {
           </Box>
         </OverlayDialog>
       </Grid>
+      {tableOfContents.length > 0 && (
+        <Grid item xs={12} md={2}>
+          <Box sx={{ display: { md: 'block', xs: 'none' } }}>
+            <TableOfContents toc={tableOfContents} prevTagArray={['', 0]} />
+          </Box>
+        </Grid>
+      )}
     </Grid>
   );
 }

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Typography, List, ListItem } from '@mui/material';
+import { Link } from './Link';
+
+type HeaderItem = {
+  id: string;
+  tagName: string;
+  title: string;
+};
+
+interface PropsTableOfContents {
+  toc: HeaderItem[];
+  prevTagArray: (string | number)[];
+}
+
+export function TableOfContents(props: PropsTableOfContents) {
+  const { toc, prevTagArray } = props;
+
+  if (!toc || !prevTagArray) {
+    return null;
+  }
+
+  function calculateLevel(tag: string, operation: string) {
+    const prevTagLevel = prevTagArray[1].toString();
+    let newValue;
+
+    if (operation === 'add') {
+      newValue = parseInt(prevTagLevel, 10) + 1;
+    } else if (operation === 'minus') {
+      newValue = parseInt(prevTagLevel, 10) - 1;
+      if (newValue < 0) {
+        newValue = 0;
+      }
+    }
+    const newLevel = `${newValue.toString()}rem`;
+    prevTagArray[0] = tag;
+    prevTagArray[1] = newValue;
+    return newLevel;
+  }
+
+  function handleIrregularTags(tag: string) {
+    if (prevTagArray[0] === '') {
+      prevTagArray[0] = tag;
+      return '0rem';
+    }
+
+    const prevTagName = prevTagArray[0].toString();
+    const prevLevel = parseInt(prevTagName.substring(1), 10);
+    const currLevel = parseInt(tag.substring(1), 10);
+
+    if (prevLevel < currLevel) {
+      return calculateLevel(tag, 'add');
+    }
+    if (prevLevel === currLevel) {
+      return `${prevTagArray[1].toString()}rem`;
+    }
+    return calculateLevel(tag, 'minus');
+  }
+
+  return (
+    <nav className="" style={{ paddingLeft: '1rem' }}>
+      <Typography variant="body1" component="h3" sx={{ fontWeight: 'bold' }}>
+        On this page
+      </Typography>
+      <List>
+        {toc.map((item) => (
+          <ListItem
+            key={item.id}
+            className={item.tagName === 'h3' ? 'ml-3' : ''}
+            style={{ color: 'black', paddingLeft: 0 }}>
+            <Link
+              sx={{
+                '&:hover': {
+                  color: 'rgba(0, 0, 0, 1.0)',
+                },
+                textDecoration: 'none',
+                listStyleType: 'none',
+                color: 'rgba(0, 0, 0, 0.6)',
+                display: 'flex',
+                flex: '1',
+                fontSize: '0.93rem',
+                transition: '0.2s ease',
+                px: handleIrregularTags(item.tagName),
+              }}
+              href={item.id}>
+              {item.title}
+            </Link>
+          </ListItem>
+        ))}
+      </List>
+    </nav>
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,8 @@
 import { WordPressTemplate } from '@faustwp/core';
 
 export type WordPressTemplateProps = Parameters<typeof WordPressTemplate>[0];
+export type HeaderItem = {
+  id: string; // anchor link
+  tagName: string; // h[1-6]
+  title: string; // name of heading
+};

--- a/src/utility/buildTableOfContents.ts
+++ b/src/utility/buildTableOfContents.ts
@@ -1,0 +1,58 @@
+import { HeaderItem } from '../types';
+
+// headerRegex is for parsing the tag in the form <h[#] [any classes, ids, etc]> [Text] </h[#]>
+const headerRegex = /<(h[1-6]{1})[^>]*>(.*)<\/h[1-6]{1}>/g;
+// headerLinkRegex is for parsing the anchor from existing <a href> tags if included in header
+const headerLinkRegex = /#[\w-]*/g;
+// remove <code> tags in the title, and characters that didn't translate (example: &nbsp; )
+const codeRegex = /<\/*code>(&nbsp;)*/g;
+const unrenderedChar = /&.{4,5};/g;
+
+// use regex to find all headings in content
+function extractHeaders(content: string) {
+  const arr = [...content.matchAll(headerRegex)];
+  return arr;
+}
+
+export function buildTableOfContents(content: string) {
+  const returnDict: HeaderItem[] = [];
+  const headers = extractHeaders(content);
+
+  for (let ind = 0; ind < headers.length; ind += 1) {
+    const element = headers[ind];
+
+    let id = '#';
+    const tagName = element[1];
+    const headerText = element[2];
+    let headerTitle;
+
+    if (headerText.search('<a href') === -1) {
+      // this section creates an anchor link if not included
+      // however, since a doesn't already exist, the link to it in the sidebar won't work
+      headerTitle = headerText
+        .replace(codeRegex, ' ')
+        .replace(unrenderedChar, '');
+      id += headerTitle
+        .replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, ' ') // replace punctuation
+        .replace(/\s{2,}/g, ' ') // ensure spaces are only 1 character long
+        .toLowerCase()
+        .trim()
+        .replaceAll(/\s/g, '-'); // replace spaces with -
+    } else {
+      // extract anchor from existing tag
+      headerTitle = headerText
+        .substring(0, headerText.search('<a href'))
+        .replace(codeRegex, ' ')
+        .replace(unrenderedChar, '');
+      const idValues = Array(headerText.match(headerLinkRegex));
+
+      if (idValues[0] !== null) {
+        id = `${idValues[0]}`;
+      }
+    }
+
+    returnDict.push({ id, tagName, title: headerTitle });
+  }
+
+  return returnDict;
+}

--- a/src/wp-templates/SingleFaustExplanation.tsx
+++ b/src/wp-templates/SingleFaustExplanation.tsx
@@ -14,6 +14,7 @@ import {
   SidebarLayout,
   Main,
 } from 'components';
+import { buildTableOfContents } from '../utility/buildTableOfContents';
 
 const Component: FaustTemplate<GetExplanationQuery> = (props) => {
   const { loading, data } = props;
@@ -52,7 +53,8 @@ const Component: FaustTemplate<GetExplanationQuery> = (props) => {
           <SidebarLayout
             menuItems={
               docsSidebarMenuItems.nodes as DocsSidebarMenuItemsFragmentFragment[]
-            }>
+            }
+            tableOfContents={buildTableOfContents(content)}>
             <EntryHeader title={title} />
             <div
               // eslint-disable-next-line react/no-danger

--- a/src/wp-templates/SingleFaustHowToGuide.tsx
+++ b/src/wp-templates/SingleFaustHowToGuide.tsx
@@ -14,6 +14,7 @@ import {
   SidebarLayout,
   Main,
 } from 'components';
+import { buildTableOfContents } from '../utility/buildTableOfContents';
 
 const Component: FaustTemplate<GetHowToGuideQuery> = (props) => {
   const { loading, data } = props;
@@ -52,7 +53,8 @@ const Component: FaustTemplate<GetHowToGuideQuery> = (props) => {
           <SidebarLayout
             menuItems={
               docsSidebarMenuItems.nodes as DocsSidebarMenuItemsFragmentFragment[]
-            }>
+            }
+            tableOfContents={buildTableOfContents(content)}>
             <EntryHeader title={title} />
             <div
               // eslint-disable-next-line react/no-danger

--- a/src/wp-templates/SingleFaustReference.tsx
+++ b/src/wp-templates/SingleFaustReference.tsx
@@ -14,6 +14,7 @@ import {
   SidebarLayout,
   Main,
 } from 'components';
+import { buildTableOfContents } from '../utility/buildTableOfContents';
 
 const Component: FaustTemplate<GetReferenceQuery> = (props) => {
   const { loading, data } = props;
@@ -52,7 +53,8 @@ const Component: FaustTemplate<GetReferenceQuery> = (props) => {
           <SidebarLayout
             menuItems={
               docsSidebarMenuItems.nodes as DocsSidebarMenuItemsFragmentFragment[]
-            }>
+            }
+            tableOfContents={buildTableOfContents(content)}>
             <EntryHeader title={title} />
             <div
               // eslint-disable-next-line react/no-danger

--- a/src/wp-templates/SingleFaustTutorial.tsx
+++ b/src/wp-templates/SingleFaustTutorial.tsx
@@ -14,6 +14,7 @@ import {
   SidebarLayout,
   Main,
 } from 'components';
+import { buildTableOfContents } from '../utility/buildTableOfContents';
 
 const Component: FaustTemplate<GetTutorialQuery> = (props) => {
   const { loading, data } = props;
@@ -52,7 +53,8 @@ const Component: FaustTemplate<GetTutorialQuery> = (props) => {
           <SidebarLayout
             menuItems={
               docsSidebarMenuItems.nodes as DocsSidebarMenuItemsFragmentFragment[]
-            }>
+            }
+            tableOfContents={buildTableOfContents(content)}>
             <EntryHeader title={title} />
             <div
               // eslint-disable-next-line react/no-danger

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
       ]
     },
     "target": "es5",
+    "downlevelIteration": true,
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
[MERL-1042](https://wpengine.atlassian.net/browse/MERL-1042): Implement linkable headings within docs

To implement the table of contents, the `content` information returned by GraphQL is parsed to find all the headings and their anchor links if included (parsing code in **buildTableOfContents.ts**, component in **TableOfContents.ts**). The table is rendered through the **SidebarLayout** component as a prop.

Noted issue with this PR: Some pages have headings that don't automatically have their anchor links set up. For example the "Get Started With Faust" tutorial page's headings aren't connected to any anchors, so the links in the table of contents won't work. 

Similarly on the "Get started with wp-graphql-content-blocks", the first heading doesn't have an anchor so the link doesn't work; however, the other 4 headers have anchors and so those links are connected. I'm not sure why some of the headings have these anchors while others do not.

For context, in the `content` string returned by GraphQL, some headers are formatted like this: 
  `<h4 class=\"wp-block-heading\">Introduction</h4>`
While others are formatted like this: 
  `<h2 class=\"wp-block-heading\" id=\"getting-started\">Getting started<a href=\"https://faustjs.org/docs/gutenberg/wp-graphql-content-blocks#getting-started\">​</a></h2>`

If an 'a href' tag is included in the header, then the table of contents in the sidebar will be able to jump to those sections of the page. If they don't include that tag though, it will not be able to link to the header. However, I've still included a method to populate the anchor link for the headers that don't have it based on the text in the header. The issue now is to create those anchors if they're missing in each post. 

The other issue is stylistic: we could consider reducing the page's left and right margin to allow for the table of contents column to be a little wider. I couldn't figure out where that could be adjusted.

[MERL-1042]: https://wpengine.atlassian.net/browse/MERL-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ