### PR TITLE
Handle exception cases with anchor links

### DIFF
--- a/src/utility/buildTableOfContents.ts
+++ b/src/utility/buildTableOfContents.ts
@@ -12,7 +12,7 @@ function extractHeaders(content: string) {
   return arr;
 }
 
-export function buildTableOfContents(content: string, title?: string) {
+export function buildTableOfContents(content: string) {
   const returnDict: HeaderItem[] = [];
   const headers = extractHeaders(content);
 
@@ -22,20 +22,15 @@ export function buildTableOfContents(content: string, title?: string) {
     const tagName = element[1];
     const id = `#${element[2]}`;
     const headerText = element[3];
-    let headerTitle;
+    let headerTitle = headerText;
 
-    console.log('extracted ID value:', id);
-
-    if (headerText.search('<a href') === -1) {
-      headerTitle = headerText
-        .replace(codeRegex, ' ')
-        .replace(unrenderedChar, '');
-    } else {
-      headerTitle = headerText
-        .substring(0, headerText.search('<a href'))
-        .replace(codeRegex, ' ')
-        .replace(unrenderedChar, '');
+    if (headerText.search('<a href') !== -1) {
+      headerTitle = headerText.substring(0, headerText.search('<a href'));
     }
+
+    headerTitle = headerTitle
+      .replace(codeRegex, ' ')
+      .replace(unrenderedChar, '');
 
     returnDict.push({ id, tagName, title: headerTitle });
   }

--- a/src/wp-templates/SingleFaustReference.tsx
+++ b/src/wp-templates/SingleFaustReference.tsx
@@ -54,7 +54,7 @@ const Component: FaustTemplate<GetReferenceQuery> = (props) => {
             menuItems={
               docsSidebarMenuItems.nodes as DocsSidebarMenuItemsFragmentFragment[]
             }
-            tableOfContents={buildTableOfContents(content, title)}>
+            tableOfContents={buildTableOfContents(content)}>
             <EntryHeader title={title} />
             <div
               // eslint-disable-next-line react/no-danger


### PR DESCRIPTION
[MERL-1123](https://wpengine.atlassian.net/browse/MERL-1123): Updated code to handle exceptions for certain pages and to fix some edge cases.

Pages to check:

- https://faustjs.org/reference/faust-plugin-system-filters - ~should no longer show the Config/Context Object headers in Table of Contents (TOC)~
- https://faustjs.org/guide/how-to-migrate-from-wp-graphql-gutenberg - the first two headers links in TOC should connect to the anchors and not have '?' in the url.
- https://faustjs.org/guide/how-to-create-a-block-from-the-wordpress-blocks-list - 3.1, 3.2, 4.2, and "Create and import block styles" and section 2 under section 5 should all link correctly.
- https://faustjs.org/guide/creating-a-custom-block - section 5 should link correctly


[MERL-1123]: https://wpengine.atlassian.net/browse/MERL-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ