### PR TITLE
Create noindex meta for staging site

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -10,10 +10,12 @@ import { FaustAppProps } from './_app';
  * @returns boolean
  */
 function isProd() {
-  return (
-    process.env.NEXT_PUBLIC_IS_PROD &&
-    process.env.NEXT_PUBLIC_IS_PROD === 'true'
-  );
+  // If the env var is not set, assume prod.
+  if (!process.env.NEXT_PUBLIC_IS_PROD) {
+    return true;
+  }
+
+  return process.env.NEXT_PUBLIC_IS_PROD === 'true';
 }
 
 export default class MyDocument extends Document {


### PR DESCRIPTION
a `NEXT_PUBLIC_IS_PROD` environment variable will need to be set on the prod faustjs.org site and staging site. This will conditionally apply the meta `noindex` logic for each page.