### PR TITLE
Changed social media avatar box to display:flex

### DIFF
--- a/src/components/TopHeaderAppBar.tsx
+++ b/src/components/TopHeaderAppBar.tsx
@@ -137,7 +137,7 @@ export function TopHeaderAppBar({
 
           <HeaderSearch />
 
-          <Box sx={{ display: { xs: 'none', md: 'block' } }}>
+          <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
             {secondaryMenuItems.map((item) => (
               <Link
                 className={cx('social-navigation-link')}


### PR DESCRIPTION
This fix addresses [MERL-1302](https://wpengine.atlassian.net/jira/software/c/projects/MERL/boards/1007?selectedIssue=MERL-1302) and realigns the social media icons using `display:flex.`

Testing: 

- Pull down this branch. 
- Run `run install`, `npm run build`, and `npm run dev`
- In a new terminal window, run `npm run start`
- Observe that the icons are now aligned.

[MERL-1302]: https://wpengine.atlassian.net/browse/MERL-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ