### PR TITLE
Add link to the showcase card

### DIFF
--- a/src/components/ShowcaseCard.tsx
+++ b/src/components/ShowcaseCard.tsx
@@ -22,12 +22,14 @@ export function ShowcaseCard({ imageSrc, title, alt, url }: ShowcaseCardProps) {
   return (
     <Card sx={{ maxWidth: 345 }} className={styles.card}>
       <CardActionArea className={styles.image}>
-        <CardMedia
-          component="img"
-          className={styles.container}
-          image={imageSrc}
-          alt={alt}
-        />
+        <Link href={url}>
+          <CardMedia
+            component="img"
+            className={styles.container}
+            image={imageSrc}
+            alt={alt}
+          />
+        </Link>
         <CardContent className={styles.fade}>
           <Grid
             id="top-row"


### PR DESCRIPTION
Clicking on the screenshot in the showcase did not link me to the site. This wraps a `<Link>` around the image so that it works as expected.