### PR TITLE
Fix x frame option headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,20 @@ module.exports = withFaust({
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value:
+              "frame-ancestors https://*.faustjs.org https://faustjs.org http://localhost:3000",
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
# Description

Guard site against various security threats such as cross-site scripting (XSS), clickjacking, and other code injection attacks using frame-ancestors Policy

https://content-security-policy.com/frame-ancestors/

# Testing

- Start the server on localhost:3000
- Serve this html file using a http server. For example here is one with python:

```bash
python3 -m http.server 9000
```

```
<html>
    <head>
        <title>Clickjack test page</title>
    </head>
    <body>
        <iframe src="http://localhost:3000" width="500" height="500"></iframe>
    </body>
</html>
```

You should not be able to see the site loaded in an iFrame
