### PR TITLE
feat: update isr config to follow beta procedure [NEB-2656]

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,26 +1,10 @@
 const { withFaust, getWpHostname } = require('@faustwp/core');
-
-// handle atlas isr cache
-const getAtlasCacheHandler = (config = {}) => {
-  if (process.env.ATLAS_CACHE_HANDLER_ENABLED === undefined) {
-    return { ...config };
-  }
-
-  return {
-    ...config,
-    ...{
-      incrementalCacheHandlerPath: require.resolve(
-        './.atlas/atlas-cache-handler.js',
-      ),
-      isrMemoryCacheSize: 0,
-    },
-  };
-};
+const { withAtlasConfig } = require("@wpengine/atlas-next");
 
 /**
  * @type {import('next').NextConfig}
  **/
-module.exports = withFaust({
+module.exports = withAtlasConfig(withFaust({
   images: {
     remotePatterns: [
       {
@@ -274,7 +258,4 @@ module.exports = withFaust({
       },
     ];
   },
-  experimental: {
-    ...getAtlasCacheHandler(),
-  },
-});
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@faustwp/core": "^1.1.2",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.12.1",
+        "@wpengine/atlas-next": "^1.0.0",
         "graphql": "^16.8.1",
         "next": "^14.0.3",
         "react": "^18.2.0",
@@ -5772,6 +5773,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wpengine/atlas-next": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wpengine/atlas-next/-/atlas-next-1.0.0.tgz",
+      "integrity": "sha512-eqrwYCGiaKIuMziIGnEe2hdEJeaFwZrmgOgXGk68qYsAmEaofN/BKU1tZyyKClgcKNeDl+n4SFAAYR/EfjP9TQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "next": ">=12.2.0 ",
+        "node-fetch": ">=2.6.1 <3"
       }
     },
     "node_modules/@wry/context": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@faustwp/core": "^1.1.2",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.1",
+    "@wpengine/atlas-next": "^1.0.0",
     "graphql": "^16.8.1",
     "next": "^14.0.3",
     "react": "^18.2.0",


### PR DESCRIPTION
**Description:**
- The staging and production faustjs.org sites are currently part of the ISR alpha that Nebula have been working on
- This sprint we've released the beta version which enables ISR in a different manner and is installed using an NPM package
- Full steps for enabling ISR for beta users are here: https://github.com/wpengine/developers/pull/138

**Other Notes:**
- We will also need to remove the `ATLAS_CACHE_HANDLER_ENABLED` variable from both environments after this change has been merged to prod