### PR TITLE
fix: use fallback string when SEO data is missing

### DIFF
--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -30,8 +30,8 @@ const Page: FaustPage<GetPostsPageQuery> = (props) => {
     <>
       <Head
         title={siteTitle}
-        description={blogSeo.metaDesc}
-        imageUrl={blogSeo.opengraphImage.sourceUrl}
+        description={blogSeo?.metaDesc || ''}
+        imageUrl={blogSeo?.opengraphImage?.sourceUrl || ''}
       />
 
       <Header

--- a/src/pages/contact/index.tsx
+++ b/src/pages/contact/index.tsx
@@ -103,8 +103,8 @@ const Page: FaustPage<GetContactFormPageQuery> = (props) => {
     <>
       <Head
         title={siteTitle}
-        description={seo.contentTypes.mediaItem.metaDesc}
-        imageUrl={seo.openGraph.defaultImage.sourceUrl}
+        description={seo?.contentTypes?.mediaItem?.metaDesc || ''}
+        imageUrl={seo?.openGraph?.defaultImage?.sourceUrl || ''}
       />
       <Header
         siteTitle={siteTitle}

--- a/src/pages/showcase/index.tsx
+++ b/src/pages/showcase/index.tsx
@@ -27,8 +27,8 @@ const Page: FaustPage<GetShowcasesPageQuery> = (props) => {
     <>
       <Head
         title={siteTitle}
-        description={showcaseSeo.metaDesc}
-        imageUrl={showcaseSeo.opengraphImage.sourceUrl}
+        description={showcaseSeo?.metaDesc || ''}
+        imageUrl={showcaseSeo?.opengraphImage?.sourceUrl || ''}
       />
       <Header
         siteTitle={siteTitle}

--- a/src/wp-templates/FrontPage.tsx
+++ b/src/wp-templates/FrontPage.tsx
@@ -24,8 +24,8 @@ const Component: FaustTemplate<GetHomePageQuery> = (props) => {
     <>
       <Head
         title={siteTitle}
-        description={seoPages.metaDesc}
-        imageUrl={seoPages.opengraphImage.sourceUrl}
+        description={seoPages?.metaDesc || ''}
+        imageUrl={seoPages?.opengraphImage?.sourceUrl || ''}
       />
 
       <Container maxWidth={false}>

--- a/src/wp-templates/Page.tsx
+++ b/src/wp-templates/Page.tsx
@@ -30,8 +30,8 @@ const Component: FaustTemplate<GetPageQuery> = (props) => {
     <>
       <Head
         title={`${title} - ${siteTitle}`}
-        description={seo.metaDesc}
-        imageUrl={seo.opengraphImage.sourceUrl}
+        description={seo?.metaDesc || ''}
+        imageUrl={seo?.opengraphImage?.sourceUrl || ''}
       />
 
       <Header

--- a/src/wp-templates/Single.tsx
+++ b/src/wp-templates/Single.tsx
@@ -40,8 +40,8 @@ const Component: FaustTemplate<GetPostQuery> = (props) => {
     <>
       <Head
         title={`${title} - ${siteTitle}`}
-        description={seo.metaDesc}
-        imageUrl={seo.opengraphImage.sourceUrl}
+        description={seo?.metaDesc || ''}
+        imageUrl={seo?.opengraphImage?.sourceUrl || ''}
       />
 
       <Header

--- a/src/wp-templates/SingleFaustExplanation.tsx
+++ b/src/wp-templates/SingleFaustExplanation.tsx
@@ -42,8 +42,8 @@ const Component: FaustTemplate<GetExplanationQuery> = (props) => {
     <>
       <Head
         title={`${title} - ${siteTitle}`}
-        description={seo.metaDesc}
-        imageUrl={seo.opengraphImage.sourceUrl}
+        description={seo?.metaDesc || ''}
+        imageUrl={seo?.opengraphImage?.sourceUrl || ''}
       />
 
       <Header

--- a/src/wp-templates/SingleFaustHowToGuide.tsx
+++ b/src/wp-templates/SingleFaustHowToGuide.tsx
@@ -42,8 +42,8 @@ const Component: FaustTemplate<GetHowToGuideQuery> = (props) => {
     <>
       <Head
         title={`${title} - ${siteTitle}`}
-        description={seo.metaDesc}
-        imageUrl={seo.opengraphImage.sourceUrl}
+        description={seo?.metaDesc || ''}
+        imageUrl={seo?.opengraphImage?.sourceUrl || ''}
       />
 
       <Header

--- a/src/wp-templates/SingleFaustReference.tsx
+++ b/src/wp-templates/SingleFaustReference.tsx
@@ -42,8 +42,8 @@ const Component: FaustTemplate<GetReferenceQuery> = (props) => {
     <>
       <Head
         title={`${title} - ${siteTitle}`}
-        description={seo.metaDesc}
-        imageUrl={seo.opengraphImage.sourceUrl}
+        description={seo?.metaDesc || ''}
+        imageUrl={seo?.opengraphImage?.sourceUrl || ''}
       />
 
       <Header

--- a/src/wp-templates/SingleFaustTutorial.tsx
+++ b/src/wp-templates/SingleFaustTutorial.tsx
@@ -42,8 +42,8 @@ const Component: FaustTemplate<GetTutorialQuery> = (props) => {
     <>
       <Head
         title={`${title} - ${siteTitle}`}
-        description={seo.metaDesc}
-        imageUrl={seo.opengraphImage.sourceUrl}
+        description={seo?.metaDesc || ''}
+        imageUrl={seo?.opengraphImage?.sourceUrl || ''}
       />
 
       <Header


### PR DESCRIPTION
This fixes 500 errors that happen when SEO data is missing. At the time of this PR, you can see an error when viewing this page: https://faustjs.org/tutorial/getting-started-with-the-experimental-app-router

The error logs show this:
![image](https://github.com/wpengine/faustjs.org/assets/1254870/3e2eb575-7144-46b1-9a3a-b3dc85f5e737)


In the preview env for this PR, you can see the same page works: https://h8c9slrxlu08ud5azn3t2r6fc.js.wpenginepowered.com/tutorial/getting-started-with-the-experimental-app-router
