### PR TITLE
Deps path to regexp 8.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9796,10 +9796,13 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
-      "dev": true
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
+      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "overrides": {
     "semver": "^7.5.2",
-    "debug": "4.3.1"
+    "debug": "4.3.1",
+    "path-to-regexp": "8.1.0"
   }
 }


### PR DESCRIPTION
Bump path-to-regexp to 8.1.0

Fixes: https://github.com/advisories/GHSA-9wv6-86v2-598j/dependabot?query=faustjs.org