### PR TITLE
[fix]: Blog errors

### DIFF
--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -9,7 +9,8 @@ import blocks from "@/wp-blocks";
 export default function MyApp({ Component, pageProps }) {
 	return (
 		<FaustProvider pageProps={pageProps}>
-			<WordPressBlocksProvider config={{ blocks, theme: undefined }}>
+			{/*  eslint-disable-next-line unicorn/no-null */}
+			<WordPressBlocksProvider config={{ blocks, theme: null }}>
 				<Layout>
 					<Component {...pageProps} />
 				</Layout>


### PR DESCRIPTION
Filed issue for upstream bug but this is the workaround for now: https://github.com/wpengine/faustjs/issues/1986

