### PR TITLE
Add 8 more reference docs pages

### DIFF
--- a/src/pages/docs/nav.json
+++ b/src/pages/docs/nav.json
@@ -36,7 +36,40 @@
 	{
 		"title": "Reference",
 		"route": "/docs/reference/",
-		"children": []
+		"children": [
+			{
+				"title": "getSiteMapProps",
+				"route": "/docs/reference/get-site-map-props"
+			},
+			{
+				"title": "getStyles",
+				"route": "/docs/reference/get-styles"
+			},
+			{
+				"title": "getWordPressProps",
+				"route": "/docs/reference/get-wordpress-props"
+			},
+			{
+				"title": "useBlocksTheme",
+				"route": "/docs/reference/use-blocks-theme"
+			},
+			{
+				"title": "useLogin",
+				"route": "/docs/reference/use-login"
+			},
+			{
+				"title": "useLogout",
+				"route": "/docs/reference/use-logout"
+			},
+			{
+				"title": "WordPressBlocksProvider",
+				"route": "/docs/reference/wordpress-blocks-provider"
+			},
+			{
+				"title": "WordPressBlocksViewer",
+				"route": "/docs/reference/wordpress-blocks-viewer"
+			}
+		]
 	},
 	{
 		"title": "Explanation",

--- a/src/pages/docs/reference/get-site-map-props/index.mdx
+++ b/src/pages/docs/reference/get-site-map-props/index.mdx
@@ -1,10 +1,5 @@
 export const metadata = {
 	title: "getSiteMapProps",
-	category: "reference",
-	docType: "doc",
-	snippet:
-		"getSitemapProps is a server side helper function that facilitates the proxying of sitemaps from your WordPress site to your Faust frontend",
-	date: "2023-06-12",
 };
 
 `getSitemapProps` is a server side helper function that facilitates the proxying of sitemaps from your WordPress site to your Faust frontend. It is a function that is returned from inside of a [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props) Next.js function.

--- a/src/pages/docs/reference/get-styles/index.mdx
+++ b/src/pages/docs/reference/get-styles/index.mdx
@@ -1,10 +1,5 @@
 export const metadata = {
 	title: "getStyles",
-	category: "reference",
-	docType: "doc",
-	snippet:
-		"The getStyles is a helper function that is used to calculate the inline styles of a block given the current theme and block properties",
-	date: "2023-06-23",
 };
 
 The `getStyles` is a helper function that is used to calculate the inline styles of a block given the current theme and block properties. This is mainly useful when developing blocks taken from the [core WordPress blocks list](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/).

--- a/src/pages/docs/reference/get-wordpress-props/index.mdx
+++ b/src/pages/docs/reference/get-wordpress-props/index.mdx
@@ -1,10 +1,5 @@
 export const metadata = {
 	title: "getWordPressProps",
-	category: "reference",
-	docType: "doc",
-	snippet:
-		"getWordPressProps is a function that can be returned within Next.js' getStaticProps or getServerSideProps to properly setup the Faust Template Hierarchy system",
-	date: "2023-06-28",
 };
 
 `getWordPressProps` is a function that should be returned within Next.js' `getStaticProps` or `getServerSideProps` to properly setup the Faust Template Hierarchy system.

--- a/src/pages/docs/reference/use-blocks-theme/index.mdx
+++ b/src/pages/docs/reference/use-blocks-theme/index.mdx
@@ -1,10 +1,5 @@
 export const metadata = {
 	title: "useBlocksTheme",
-	category: "reference",
-	docType: "doc",
-	snippet:
-		"useBlocksTheme is a React hook that provides the theme value when passed in the WordPressBlocksProvider component",
-	date: "2023/06/28",
 };
 
 `useBlocksTheme` is a React hook that provides the theme value when passed in the `WordPressBlocksProvider` component. The theme value is sourced by a theme.json file when using the [fromThemeJson](/docs/reference/from-theme-json) helper function.

--- a/src/pages/docs/reference/use-login/index.mdx
+++ b/src/pages/docs/reference/use-login/index.mdx
@@ -1,10 +1,5 @@
 export const metadata = {
 	title: "useLogin",
-	category: "reference",
-	docType: "doc",
-	snippet:
-		"useLogin is a React hook that facilitates login to your headless WordPress site without having to leave your Faust app",
-	date: "2023-06-23",
 };
 
 `useLogin` is a React hook that facilitates login to your headless WordPress site without having to leave your Faust app.

--- a/src/pages/docs/reference/use-logout/index.mdx
+++ b/src/pages/docs/reference/use-logout/index.mdx
@@ -1,10 +1,5 @@
 export const metadata = {
 	title: "useLogout",
-	category: "reference",
-	docType: "doc",
-	snippet:
-		"useLogout is a React hook that facilitates logout from your Faust app",
-	date: "2023-06-23",
 };
 
 `useLogout` is a React hook that facilitates logging out from your Faust app.

--- a/src/pages/docs/reference/wordpress-blocks-provider/index.mdx
+++ b/src/pages/docs/reference/wordpress-blocks-provider/index.mdx
@@ -1,10 +1,5 @@
 export const metadata = {
 	title: "WordPressBlocksProvider",
-	category: "reference",
-	docType: "doc",
-	snippet:
-		"WordPressBlocksProvider is a React Context Provider that exposes the data that WordPressBlocksViewer needs to render WordPress blocks",
-	date: "2023-06-23",
 };
 
 `WordPressBlocksProvider` is a React [Context Provider](https://react.dev/reference/react/createContext#provider) that exposes the data that `WordPressBlocksViewer` needs to render WordPress blocks, namely which blocks have been defined as a part of your Faust app.
@@ -14,27 +9,32 @@ export const metadata = {
 The below example shows how you can setup the `WordPressBlocksProvider` in your Faust app's `_app.js` file:
 
 ```js title="pages/_app.js"
-import '../faust.config';
-import React from 'react';
-import { useRouter } from 'next/router';
-import { WordPressBlocksProvider } from '@faustwp/blocks'; // [!code ++]
-import { FaustProvider } from '@faustwp/core';
-import blocks from '../wp-blocks/index.js';
+import "../faust.config";
+import React from "react";
+import { useRouter } from "next/router";
+import { WordPressBlocksProvider } from "@faustwp/blocks"; // [!code ++]
+import { FaustProvider } from "@faustwp/core";
+import blocks from "../wp-blocks/index.js";
 
 export default function MyApp({ Component, pageProps }) {
-  const router = useRouter();
+	const router = useRouter();
 
-  return (
-    <FaustProvider pageProps={pageProps}>
-      <WordPressBlocksProvider // [!code ++]
-        config={{ // [!code ++]
-          blocks, // [!code ++]
-          theme: null // [!code ++]
-        }}> // [!code ++]
-        <Component {...pageProps} key={router.asPath} />
-      </WordPressBlocksProvider> // [!code ++]
-    </FaustProvider>
-  );
+	return (
+		<FaustProvider pageProps={pageProps}>
+			<WordPressBlocksProvider // [!code ++]
+				config={{
+					// [!code ++]
+					blocks, // [!code ++]
+					theme: null, // [!code ++]
+				}}
+			>
+				{" "}
+				// [!code ++]
+				<Component {...pageProps} key={router.asPath} />
+			</WordPressBlocksProvider>{" "}
+			// [!code ++]
+		</FaustProvider>
+	);
 }
 ```
 
@@ -44,10 +44,10 @@ Below are `WordPressBlocksProvider`'s props defined as a TypeScript interface:
 
 ```ts
 interface WordPressBlocksProviderProps {
-  config: {
-    blocks?: { [key: string]: WordPressBlock };
-    theme?: BlocksTheme
-  };
+	config: {
+		blocks?: { [key: string]: WordPressBlock };
+		theme?: BlocksTheme;
+	};
 }
 ```
 
@@ -55,39 +55,39 @@ The `config` prop accepts a `blocks` property, which is an map of block names to
 
 ```ts
 type WordPressBlock = React.FC & {
-  displayName?: string;
-  name?: string;
-  config?: {
-    name: string;
-  };
+	displayName?: string;
+	name?: string;
+	config?: {
+		name: string;
+	};
 };
 ```
 
 The `blocks` property is typically set to a path of `wp-blocks/index.js`:
 
 ```js
-import { WordPressBlocksProvider } from '@faustwp/blocks';
-import blocks from '../wp-blocks/index.js'; // [!code ++]
+import { WordPressBlocksProvider } from "@faustwp/blocks";
+import blocks from "../wp-blocks/index.js"; // [!code ++]
 
 <WordPressBlocksProvider
-  config={{
-    blocks,
-    theme: null
-  }}
-/>
-  ```
+	config={{
+		blocks,
+		theme: null,
+	}}
+/>;
+```
 
 The theme property is an optional parameter that is used to assign a ThemeProvider for a theme.json and will be available in the `useBlocksTheme` hook. You will need to use the `fromThemeJson` helper to transform a `theme.json` object into the `BlocksTheme` type:
 
 ```js
-import { WordPressBlocksProvider } from '@faustwp/blocks';
-import blocks from '../wp-blocks/index.js';
-import themeJson from '../theme.json'; // [!code ++]
+import { WordPressBlocksProvider } from "@faustwp/blocks";
+import blocks from "../wp-blocks/index.js";
+import themeJson from "../theme.json"; // [!code ++]
 
 <WordPressBlocksProvider
-  config={{
-    blocks,
-    theme: fromThemeJson(themeJson) // [!code ++]
-  }}
-/>
+	config={{
+		blocks,
+		theme: fromThemeJson(themeJson), // [!code ++]
+	}}
+/>;
 ```

--- a/src/pages/docs/reference/wordpress-blocks-viewer/index.mdx
+++ b/src/pages/docs/reference/wordpress-blocks-viewer/index.mdx
@@ -1,10 +1,5 @@
 export const metadata = {
 	title: "WordPressBlocksViewer",
-	category: "reference",
-	docType: "doc",
-	snippet:
-		"WordPressBlocksViewer is a component used to render blocks received from WordPress",
-	date: "2023-06-23",
 };
 
 `WordPressBlocksViewer` is a component used to render blocks received from WordPress. It uses the React components passed to the `WordPressBlocksProvider` and matches them to the appropriate blocks received in the `editorBlocks` prop.


### PR DESCRIPTION
This PR adds the following 8 reference docs pages:

- get-site-map-props
- get-styles
- get-wordpress-props
- use-blocks-theme
- use-login
- use-logout
- wordpress-blocks-provider
- wordpress-blocks-viewer
