### PR TITLE
(fix): docs nav mobile menu

### DIFF
--- a/src/components/docs-layout.jsx
+++ b/src/components/docs-layout.jsx
@@ -14,7 +14,7 @@ export default function DocumentPage({ children }) {
 		<>
 			<Disclosure
 				as="div"
-				className="sticky top-[84px] border-b-[1px] border-gray-800 bg-gray-900/80 backdrop-blur-sm md:hidden"
+				className="sticky top-[85px] z-10 border-b-[1px] border-gray-800 bg-gray-900/80 backdrop-blur-sm md:hidden"
 			>
 				<DisclosureButton className="group flex items-center rounded-md px-2 py-1.5 text-white/70 hover:text-white">
 					<ChevronDownIcon className="relative z-20 hidden h-4 w-4 group-data-[open]:inline" />


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/95d672fb-7b15-40d6-b3b1-966b4ccccad4)
