### PR TITLE
Fix: Added context and provider to `_app.js` section and fixed typo in Rendering Blocks doc page

### DIFF
--- a/src/pages/docs/how-to/rendering-blocks/index.mdx
+++ b/src/pages/docs/how-to/rendering-blocks/index.mdx
@@ -71,7 +71,6 @@ export default function MyApp({ Component, pageProps }) {
 			<WordPressBlocksProvider
 				config={{
 					blocks,
-					theme: null,
 				}}
 			>
 				<Component {...pageProps} key={router.asPath} />


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209344840360648