### PR TITLE
Chore: Various UX fixes

### DIFF
--- a/src/components/docs-previous-next-link.jsx
+++ b/src/components/docs-previous-next-link.jsx
@@ -19,24 +19,27 @@ export default function DocsPreviousNextLinks({ routes }) {
 	const nextPage = routes[currentIndex + 1];
 
 	return (
-		<nav aria-label="pagination" className="mt-8 mb-4 flex justify-between">
+		<nav
+			aria-label="pagination"
+			className="mt-8 mb-4 flex justify-between space-x-2"
+		>
 			{previousPage && (
 				<Link
-					className="max-w-[200px] font-normal text-gray-400 no-underline transition duration-200 ease-in hover:text-white focus:text-white"
+					className="max-w-[50%] font-normal text-gray-400 no-underline transition duration-200 ease-in hover:text-white focus:text-white"
 					href={previousPage.route}
 					noDefaultStyles
 					aria-label={`Go to previous page: ${previousPage.title}`}
 				>
-					<span className="mb-1 ml-10 block text-sm">Previous</span>
+					<span className="mb-1 block text-sm sm:ml-10">Previous</span>
 					<span>
-						<ChevronLeftIcon className="inline h-5 w-10 pr-4 align-text-top" />
+						<ChevronLeftIcon className="hidden h-5 w-10 pr-4 align-text-top sm:inline" />
 					</span>
 					<span className="text-white">{previousPage.title}</span>
 				</Link>
 			)}
 			{nextPage && (
 				<Link
-					className="max-w-[200px] font-normal text-gray-400 no-underline transition duration-200 ease-in hover:text-white focus:text-white"
+					className="max-w-[50%] font-normal text-gray-400 no-underline transition duration-200 ease-in hover:text-white focus:text-white"
 					href={nextPage.route}
 					noDefaultStyles
 					aria-label={`Go to next page: ${nextPage.title}`}
@@ -44,7 +47,7 @@ export default function DocsPreviousNextLinks({ routes }) {
 					<span className="mb-1 block text-sm">Next</span>
 					<span className="text-white">{nextPage.title}</span>
 					<span>
-						<ChevronRightIcon className="inline h-5 w-10 pl-4 align-text-top" />
+						<ChevronRightIcon className="hidden h-5 w-10 pl-4 align-text-top sm:inline" />
 					</span>
 				</Link>
 			)}

--- a/src/components/heading.jsx
+++ b/src/components/heading.jsx
@@ -7,7 +7,7 @@ export default function Heading({ level, children, id, ...props }) {
 	return (
 		<Tag
 			id={id.toString()}
-			className="group flex items-center hover:text-blue-500"
+			className="group flex items-center break-words hover:text-blue-500"
 			{...props}
 		>
 			<Link

--- a/src/components/heading.jsx
+++ b/src/components/heading.jsx
@@ -7,12 +7,12 @@ export default function Heading({ level, children, id, ...props }) {
 	return (
 		<Tag
 			id={id.toString()}
-			className="group flex items-center break-words hover:text-blue-500"
+			className="group flex items-center hover:text-blue-500"
 			{...props}
 		>
 			<Link
 				href={`#${id}`}
-				className="no-underline transition-colors group-hover:text-blue-500"
+				className="break-all no-underline transition-colors group-hover:text-blue-500"
 				noDefaultStyles
 			>
 				{children}


### PR DESCRIPTION
Solves #290 

1. Fixed break word for mobile for docs headings
2. Added space between prev/next links
3. Hidden arrow on mobile as it was causing issues with text on multiple lines 
4. Fixed a width issues for the pagination text.

Screenshots:

<img width="1003" alt="Screenshot 2025-02-21 at 15 13 52" src="https://github.com/user-attachments/assets/03aa5ab4-9c7c-40f1-840d-27bac532bea7" />

<img width="516" alt="Screenshot 2025-02-21 at 15 14 05" src="https://github.com/user-attachments/assets/e48fffb9-a809-45e2-83f0-b3b4c8a2b9d1" />

<img width="604" alt="Screenshot 2025-02-21 at 15 17 33" src="https://github.com/user-attachments/assets/f1585ebc-4a50-4ee8-9370-6046940d6476" />

