### PR TITLE
Added spacing between logo and menu items in the header.

### DIFF
--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -32,7 +32,7 @@ export default function Header() {
 			)}
 		>
 			<header className="container mx-auto flex items-center justify-between px-4 py-6 sm:px-6 md:max-w-6xl md:px-8">
-				<div className="flex items-center gap-8">
+				<div className="mr-8 flex items-center gap-8">
 					<Link
 						className="transition-duration-75 flex items-center text-xl font-bold transition hover:text-white focus:text-white"
 						href="/"


### PR DESCRIPTION
Added margin between the logo and menu items.

See attached.

<img width="1249" alt="Screenshot 2025-02-24 at 19 26 10" src="https://github.com/user-attachments/assets/c4624c82-5ce5-4c20-bca8-cb5d04b16199" />


For reference here is an old screenshot before the [snag](https://private-user-images.githubusercontent.com/682403/394297000-2c229a48-f675-4d06-877e-31b668930a13.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDA0MjUwNDMsIm5iZiI6MTc0MDQyNDc0MywicGF0aCI6Ii82ODI0MDMvMzk0Mjk3MDAwLTJjMjI5YTQ4LWY2NzUtNGQwNi04NzdlLTMxYjY2ODkzMGExMy5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwMjI0JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDIyNFQxOTE5MDNaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1mZWYzOTE1OTMxZDY0MzRkZDg0ZjliYWMzMWNiOGI0OWVhY2NlN2M5ZDA4ZWVhZTkzOGE1ZmQyNjIzMzNmYTBkJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.cBOaa8rNpHGJEJUkSln8rejoUaYP--9PHLOLFg1AOfs)