### PR TITLE
chore: Update babel runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
 			"sharp"
 		],
 		"overrides": {
-			"eslint-plugin-unicorn": "$eslint-plugin-unicorn"
+			"eslint-plugin-unicorn": "$eslint-plugin-unicorn",
+			"@babel/runtime": "^7.27.0"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   eslint-plugin-unicorn: ^57.0.0
+  '@babel/runtime': ^7.27.0
 
 importers:
 
@@ -16,13 +17,13 @@ importers:
         version: 3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@faustwp/blocks':
         specifier: ^6.1.0
-        version: 6.1.0(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@faustwp/core@3.2.1(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@wordpress/style-engine@2.11.0)(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 6.1.2(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@faustwp/core@3.2.3(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@wordpress/style-engine@2.11.0)(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@faustwp/cli':
         specifier: ^3.2.1
-        version: 3.2.1(webpack@5.96.1)
+        version: 3.2.3(webpack@5.96.1)
       '@faustwp/core':
         specifier: ^3.2.1
-        version: 3.2.1(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 3.2.3(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@headlessui/react':
         specifier: ^2.2.0
         version: 2.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -254,12 +255,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/runtime@7.25.7':
-    resolution: {integrity: sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/runtime@7.26.10':
-    resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
+  '@babel/runtime@7.27.0':
+    resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.26.9':
@@ -353,8 +350,8 @@ packages:
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@faustwp/blocks@6.1.0':
-    resolution: {integrity: sha512-EUNyW5YV516VF2I2ioWo46U0qmUwAQaBLqeAu2AkC+okaZ11TEPnYOMDZFcx3TrS4q2tGtiw2IZdCFGqgo5PZw==}
+  '@faustwp/blocks@6.1.2':
+    resolution: {integrity: sha512-JUFMAQaEVzi17XGLjWG+tbhMZABl7T9j0qKwjud35pPBc+mbW9r3YHvcbhx0D+zWcv6gY719h9divFxmJufPDA==}
     engines: {node: '>=18', npm: '>=8'}
     peerDependencies:
       '@apollo/client': '>=3.6.6'
@@ -364,13 +361,13 @@ packages:
       react: '>=17.0.2'
       react-dom: '>=17.0.2'
 
-  '@faustwp/cli@3.2.1':
-    resolution: {integrity: sha512-ZQ7UYROGd6BNiVniJJ0XulJzx2BBIHkkLplMTDWt+spmnONMFl+94hc+2mKzoX0WQVQ5tTszmuidr65N347iBQ==}
+  '@faustwp/cli@3.2.3':
+    resolution: {integrity: sha512-xrLPJnyZBm7CfeutYE7hTB1N9/mszdvth2YkuH2h1CRFyK2pc9+yH2i9XAjRMpuNTJKGqhEcg+g+gAHyecMfuw==}
     engines: {node: '>=18', npm: '>=8'}
     hasBin: true
 
-  '@faustwp/core@3.2.1':
-    resolution: {integrity: sha512-lEwYdZ38rO4/YHQyVOsTouHPdFLTYA7cnBQvraqQAEXrwUQEN6xtyU/LYZ44xd3QWwHNbzFSlWdTgtYZB+0Euw==}
+  '@faustwp/core@3.2.3':
+    resolution: {integrity: sha512-p7VpO9kUkz9oPxRsWcuLLNXtayyS+8xlotI9fc5wZsRyI9CVcdXtQk0MkM8Ojai0L3grt9zvut5WWI3dxIldug==}
     engines: {node: '>=18', npm: '>=8'}
     peerDependencies:
       '@apollo/client': '>=3.6.6'
@@ -937,6 +934,9 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/estree@1.0.7':
+    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -969,6 +969,9 @@ packages:
 
   '@types/node@22.13.10':
     resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
+
+  '@types/node@22.14.0':
+    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -4276,6 +4279,9 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
@@ -4622,11 +4628,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.10
 
-  '@babel/runtime@7.25.7':
-    dependencies:
-      regenerator-runtime: 0.14.1
-
-  '@babel/runtime@7.26.10':
+  '@babel/runtime@7.27.0':
     dependencies:
       regenerator-runtime: 0.14.1
 
@@ -4735,16 +4737,16 @@ snapshots:
       '@eslint/core': 0.12.0
       levn: 0.4.1
 
-  '@faustwp/blocks@6.1.0(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@faustwp/core@3.2.1(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@wordpress/style-engine@2.11.0)(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@faustwp/blocks@6.1.2(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@faustwp/core@3.2.3(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@wordpress/style-engine@2.11.0)(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@apollo/client': 3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@faustwp/core': 3.2.1(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@faustwp/core': 3.2.3(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@wordpress/style-engine': 2.11.0
       next: 15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@faustwp/cli@3.2.1(webpack@5.96.1)':
+  '@faustwp/cli@3.2.3(webpack@5.96.1)':
     dependencies:
       archiver: 6.0.2
       chalk: 4.1.2
@@ -4762,7 +4764,7 @@ snapshots:
       - webpack-bundle-analyzer
       - webpack-dev-server
 
-  '@faustwp/core@3.2.1(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@faustwp/core@3.2.3(@apollo/client@3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@apollo/client': 3.13.4(@types/react@18.3.12)(graphql@16.10.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@wordpress/hooks': 3.58.0
@@ -5380,11 +5382,11 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/json-schema': 7.0.15
 
   '@types/estree-jsx@1.0.5':
@@ -5392,6 +5394,8 @@ snapshots:
       '@types/estree': 1.0.6
 
   '@types/estree@1.0.6': {}
+
+  '@types/estree@1.0.7': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -5425,6 +5429,10 @@ snapshots:
   '@types/node@22.13.10':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/node@22.14.0':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -5705,11 +5713,11 @@ snapshots:
 
   '@wordpress/hooks@3.58.0':
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.0
 
   '@wordpress/style-engine@2.11.0':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.27.0
       change-case: 4.1.2
 
   '@wpengine/atlas-next@2.0.1(next@15.2.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(node-fetch@2.7.0)':
@@ -6277,7 +6285,7 @@ snapshots:
 
   downshift@9.0.9(react@19.0.0):
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.0
       compute-scroll-into-view: 3.1.1
       prop-types: 15.8.1
       react: 19.0.0
@@ -7588,7 +7596,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -9574,6 +9582,8 @@ snapshots:
 
   undici-types@6.20.0: {}
 
+  undici-types@6.21.0: {}
+
   unicorn-magic@0.1.0: {}
 
   unified-engine@11.2.2:
@@ -9811,7 +9821,7 @@ snapshots:
   webpack@5.96.1(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1


### PR DESCRIPTION
- Updated faust to the latest version
- Added override for babel/runtime for moderate security vulnerability as some other packages had hard dependencies on babel/runtime - https://github.com/advisories/GHSA-968p-4wvh-cqc8