### PR TITLE
Chore fix canonicals remove queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
 		"shiki": "^3.2.1",
 		"strip-markdown": "^6.0.0",
 		"unified": "^11.0.5",
-		"unist-util-visit": "^5.0.0",
 		"vfile-matter": "^5.0.1"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
-      unist-util-visit:
-        specifier: ^5.0.0
-        version: 5.0.0
       vfile-matter:
         specifier: ^5.0.1
         version: 5.0.1

--- a/src/components/docs-layout.jsx
+++ b/src/components/docs-layout.jsx
@@ -32,6 +32,8 @@ const flattenRoutes = (routeConfig) => {
 	return flatRoutes;
 };
 
+const stripQueryParameters = (path) => path.split("?")[0];
+
 export default function DocumentPage({
 	children,
 	docsNavData: routes,
@@ -39,16 +41,19 @@ export default function DocumentPage({
 }) {
 	const flatRoutes = flattenRoutes(routes);
 	const {
-		asPath,
+		asPath: rawAsPath,
 		query: { slug = [] },
 	} = useRouter();
+
+	// Use the outer-scoped function
+	const cannonicalUrl = stripQueryParameters(rawAsPath);
 
 	return (
 		<>
 			<Seo
 				title={frontmatter?.title ?? "FALLBACK TITLE"}
 				description={frontmatter?.description}
-				url={asPath}
+				url={cannonicalUrl}
 			/>
 			<Disclosure
 				as="div"

--- a/src/components/docs-layout.jsx
+++ b/src/components/docs-layout.jsx
@@ -42,13 +42,8 @@ export default function DocumentPage({
 		query: { slug = [] },
 	} = useRouter();
 
-	// Build the path from slug
-	const canonicalPath =
-		Array.isArray(slug) && slug.length > 0
-			? `/docs/${slug.join("/")}/`
-			: "/docs/";
-
-	const canonicalUrl = `${canonicalPath}`;
+	// Build the canonical path from slug
+	const canonicalUrl = ["/docs", ...slug].join("/") + "/";
 
 	return (
 		<>

--- a/src/components/docs-layout.jsx
+++ b/src/components/docs-layout.jsx
@@ -32,8 +32,6 @@ const flattenRoutes = (routeConfig) => {
 	return flatRoutes;
 };
 
-const stripQueryParameters = (path) => path.split("?")[0];
-
 export default function DocumentPage({
 	children,
 	docsNavData: routes,
@@ -41,19 +39,23 @@ export default function DocumentPage({
 }) {
 	const flatRoutes = flattenRoutes(routes);
 	const {
-		asPath: rawAsPath,
 		query: { slug = [] },
 	} = useRouter();
 
-	// Use the outer-scoped function
-	const cannonicalUrl = stripQueryParameters(rawAsPath);
+	// Build the path from slug
+	const canonicalPath =
+		Array.isArray(slug) && slug.length > 0
+			? `/docs/${slug.join("/")}/`
+			: "/docs/";
+
+	const canonicalUrl = `${canonicalPath}`;
 
 	return (
 		<>
 			<Seo
 				title={frontmatter?.title ?? "FALLBACK TITLE"}
 				description={frontmatter?.description}
-				url={cannonicalUrl}
+				url={canonicalUrl}
 			/>
 			<Disclosure
 				as="div"

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -1,18 +1,10 @@
-import process from "node:process"; // Import process from 'node:process'
-import { URL } from "node:url"; // Import URL from the 'url' module
 import Head from "next/head";
 
 export default function SEO({ title, description, imageUrl, url }) {
-	let canonicalUrl = url
-		? new URL(url, process.env.NEXT_PUBLIC_SITE_URL)
+	const canonicalUrl = url
+		? // eslint-disable-next-line no-restricted-globals, n/prefer-global/process, n/prefer-global/url
+			new URL(url, process.env.NEXT_PUBLIC_SITE_URL)
 		: undefined;
-
-	// If the URL contains query parameters, strip them out
-	if (canonicalUrl && canonicalUrl.includes("?")) {
-		const stripQueryParameters = (path) => path.split("?")[0];
-		canonicalUrl = stripQueryParameters(url);
-		canonicalUrl = new URL(canonicalUrl, process.env.NEXT_PUBLIC_SITE_URL);
-	}
 
 	return (
 		<Head>

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -1,10 +1,18 @@
+import process from "node:process"; // Import process from 'node:process'
+import { URL } from "node:url"; // Import URL from the 'url' module
 import Head from "next/head";
 
 export default function SEO({ title, description, imageUrl, url }) {
-	const canonicalUrl = url
-		? // eslint-disable-next-line no-restricted-globals, n/prefer-global/process, n/prefer-global/url
-			new URL(url, process.env.NEXT_PUBLIC_SITE_URL)
+	let canonicalUrl = url
+		? new URL(url, process.env.NEXT_PUBLIC_SITE_URL)
 		: undefined;
+
+	// If the URL contains query parameters, strip them out
+	if (canonicalUrl && canonicalUrl.includes("?")) {
+		const stripQueryParameters = (path) => path.split("?")[0];
+		canonicalUrl = stripQueryParameters(url);
+		canonicalUrl = new URL(canonicalUrl, process.env.NEXT_PUBLIC_SITE_URL);
+	}
 
 	return (
 		<Head>

--- a/src/lib/remark-parsing.mjs
+++ b/src/lib/remark-parsing.mjs
@@ -13,7 +13,6 @@ import withSmartQuotes from "remark-smartypants";
 import remarkStringify from "remark-stringify";
 import remarkStrip from "strip-markdown";
 import { unified } from "unified";
-import { visit } from "unist-util-visit";
 import { matter } from "vfile-matter";
 import { getRemoteImgUrl } from "./remote-mdx-files.mjs";
 /**
@@ -34,28 +33,6 @@ export async function getTextContentFromMd(mdContent) {
 
 function addFrontmatterToVFile() {
 	return (_, file) => matter(file);
-}
-
-export function addTocToVFile() {
-	return (tree, file) => {
-		const toc = [];
-		visit(tree, "element", (node) => {
-			if (
-				(node.tagName === "h2" || node.tagName === "h3") &&
-				node.children[0].value
-			) {
-				const title = node.children[0]?.value;
-
-				toc.push({
-					id: node.properties.id,
-					text: title,
-					level: Number.parseInt(node.tagName[1], 10),
-				});
-			}
-		});
-
-		file.data.toc = toc;
-	};
 }
 
 /**

--- a/src/pages/docs/[[...slug]].jsx
+++ b/src/pages/docs/[[...slug]].jsx
@@ -16,7 +16,7 @@ export async function getStaticProps({ params }) {
 				source,
 				docsNavData,
 			},
-			revalidate: 1,
+			revalidate: 600,
 		};
 	} catch (error) {
 		if (error.notFound) {


### PR DESCRIPTION
In docs-layout.jsx we will format the url and send it correctly to seo.jsx.
In seo.jsx we will just cover cases where we "forgot" to format it prior passing it.

Perhaps, it is an overkill for check twice and format it but safety first. Let me know what do you think.