### PR TITLE
Make ⌘ and K characters in search bar the same height

### DIFF
--- a/src/components/search-bar.jsx
+++ b/src/components/search-bar.jsx
@@ -138,7 +138,7 @@ export default function SearchBar({ setIsSearchOpen }) {
 				<MagnifyingGlassIcon className="h-6 w-6 text-gray-400 md:hidden" />
 				<span className="hidden md:inline">
 					<span className="pl-3">Search docs...</span>
-					<kbd className="ml-8 rounded-sm bg-gray-700 px-2 py-1 text-gray-300">
+					<kbd className="ml-8 rounded-sm bg-gray-700 px-2 py-1 font-sans text-gray-400">
 						⌘K
 					</kbd>
 				</span>


### PR DESCRIPTION
Make ⌘ and K characters in search bar the same height.

Before this fix:
<img width="332" alt="Screenshot 2025-05-16 at 4 50 55 PM" src="https://github.com/user-attachments/assets/35d2a529-7f17-42e5-9acb-a9dcde980888" />

After this fix:
<img width="322" alt="Screenshot 2025-05-16 at 4 48 44 PM" src="https://github.com/user-attachments/assets/bf0b573b-470b-4240-825d-5b0fc9fec6b0" />
