### PR TITLE
Fix potential incorrect error status code in src/pages/api/recommend.js.

### DIFF
--- a/src/pages/api/recommend.js
+++ b/src/pages/api/recommend.js
@@ -65,7 +65,7 @@ export default async function handler(req, res) {
 	} catch (error) {
 		console.error("Error fetching search data:", error);
 		return res
-			.status(StatusCodes.Inter)
+			.status(StatusCodes.INTERNAL_SERVER_ERROR)
 			.json({ error: ReasonPhrases.INTERNAL_SERVER_ERROR });
 	}
 }


### PR DESCRIPTION
**Potential Issue:**
On line 67, the code uses StatusCodes.Inter, which is not a valid property of http-status-codes. This could potentially throw an error and not return the intended status code.

**Proposed Fix:**
Change StatusCodes.Inter to StatusCodes.INTERNAL_SERVER_ERROR: