### PR TITLE
chore: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @wpengine/spcs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wpengine/spcs
+* @wpengine/spcs @moonmeister


### PR DESCRIPTION
Added codeowners file. Handling off-site to @wpengine/spcs. @moonmeister left as a backup as he built the site. 

Whoever is still admin on this repo might need to add @wpengine/spcs as maintainers.