### PR TITLE
fix: drop textAlign from CoreHeading and CoreButton fragments

### DIFF
--- a/src/wp-blocks/core-button.jsx
+++ b/src/wp-blocks/core-button.jsx
@@ -1,0 +1,41 @@
+import { gql } from "@apollo/client";
+import { CoreBlocks } from "@faustwp/blocks";
+
+const { CoreButton: FaustCoreButton } = CoreBlocks;
+
+export default function CoreButton(props) {
+	return <FaustCoreButton {...props} />;
+}
+
+CoreButton.displayName = { ...FaustCoreButton.displayName };
+CoreButton.config = { ...FaustCoreButton.config };
+
+/**
+ * Faust's stock fragment requests `attributes.textAlign`, which no longer
+ * exists on `CoreButtonAttributes` in the CMS schema. GraphQL rejects the
+ * whole document at validation time, so every blog post 500s. Neither the
+ * component nor `getStyles` reads `textAlign` (alignment arrives via
+ * `cssClassName`), so dropping the field changes nothing visually.
+ */
+CoreButton.fragments = {
+	key: "CoreButtonBlockFragment",
+	entry: gql`
+		fragment CoreButtonBlockFragment on CoreButton {
+			attributes {
+				anchor
+				gradient
+				text
+				textColor
+				style
+				fontSize
+				fontFamily
+				linkTarget
+				rel
+				url
+				backgroundColor
+				cssClassName
+				linkClassName
+			}
+		}
+	`,
+};

--- a/src/wp-blocks/core-heading.jsx
+++ b/src/wp-blocks/core-heading.jsx
@@ -1,3 +1,4 @@
+import { gql } from "@apollo/client";
 import { CoreBlocks } from "@faustwp/blocks";
 import slugify from "@sindresorhus/slugify";
 
@@ -16,4 +17,30 @@ export default function CoreHeading(props) {
 
 CoreHeading.displayName = { ...FaustCoreHeading.displayName };
 CoreHeading.config = { ...FaustCoreHeading.config };
-CoreHeading.fragments = { ...FaustCoreHeading.fragments };
+/**
+ * Faust's stock fragment requests `attributes.textAlign`, which no longer
+ * exists on `CoreHeadingAttributes` in the CMS schema. GraphQL rejects the
+ * whole document at validation time, so every blog post 500s. Neither the
+ * component nor `getStyles` reads `textAlign` (alignment arrives via
+ * `cssClassName`), so dropping the field changes nothing visually.
+ */
+CoreHeading.fragments = {
+	key: "CoreHeadingBlockFragment",
+	entry: gql`
+		fragment CoreHeadingBlockFragment on CoreHeading {
+			attributes {
+				align
+				anchor
+				backgroundColor
+				content
+				fontFamily
+				fontSize
+				gradient
+				level
+				style
+				textColor
+				cssClassName
+			}
+		}
+	`,
+};

--- a/src/wp-blocks/index.js
+++ b/src/wp-blocks/index.js
@@ -1,9 +1,11 @@
 import { CoreBlocks } from "@faustwp/blocks";
+import CoreButton from "./core-button";
 import CoreEmbed from "./core-embed";
 import CoreHeading from "./core-heading";
 
 export default {
 	...CoreBlocks,
 	CoreHeading,
+	CoreButton,
 	CoreEmbed,
 };


### PR DESCRIPTION
Every blog post 500s. Nonexistent slugs 500 as well instead of 404ing, while `/blog/` is fine.

WordPress 6.8 moved `textAlign` on `core/button` from a block attribute to a block support, so WPGraphQL Content Blocks stopped exposing it. It is gone from `CoreButtonAttributes` and from `CoreHeadingAttributes`, which now uses `align`. Faust's stock heading and button fragments still request it, so GraphQL rejects the whole document at validation and `getNextStaticProps` throws before the `notFound` guard in `getStaticProps` can run. The blog index survives because its template queries `editorBlocks` without those fragments.

This overrides both fragments locally without `textAlign`. Nothing renders differently: alignment reaches the DOM through `cssClassName`, and neither the Faust component nor `getStyles` reads `textAlign`. `CoreQuote` still requests it and is left alone, since `CoreQuoteAttributes` still exposes it. Bumping `@faustwp/blocks` does not help, the current release ships the same fragments.

Upstream: wpengine/faustjs#2383. Same break as wpengine/faustjs#1932, where `align` was dropped from `CoreQuoteAttributes`.

Checked the composed query against the live schema. It fails validation on `main`, validates on this branch, and returns a null post for a nonexistent slug, which 404s correctly.

Worth a separate look: `getStaticProps` 500s on any GraphQL error rather than degrading, so the next schema change will take the blog down the same way.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): claude-opus-5
Used for: Root cause investigation, drafting, and implementation