### PR TITLE
chore: add headless-oss team to CODEOWNERS alongside spcs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wpengine/spcs @moonmeister
+* @wpengine/spcs @wpengine/headless-oss @moonmeister


### PR DESCRIPTION
Adds `@wpengine/headless-oss` alongside `@wpengine/spcs` as a code owner.

```
* @wpengine/spcs @wpengine/headless-oss @moonmeister
```

spcs stays as owner of record for security/Dependabot alerts (Jira relay); headless-oss is back in the loop for day-to-day reviews. Template for the other recently-migrated repos.

Note: used `@wpengine/headless-oss` — adjust if the recreated team slug differs.