### PR TITLE
fix: revalidate blog 404s instead of pinning them for a year

### DIFF
--- a/src/pages/blog/[slug].jsx
+++ b/src/pages/blog/[slug].jsx
@@ -108,8 +108,14 @@ export async function getStaticProps(context) {
 		revalidate: 3_600,
 	});
 
+	/**
+	 * An empty response is not proof the post is gone. A failed query returns
+	 * the same shape, so a `notFound` without `revalidate` pins a one year
+	 * `s-maxage` on what may be a transient upstream failure. Re-check on a
+	 * short interval instead.
+	 */
 	if (!props?.props?.data?.post) {
-		return { props: {}, notFound: true };
+		return { notFound: true, revalidate: 300 };
 	}
 
 	return props;


### PR DESCRIPTION
`getStaticProps` cannot distinguish a deleted post from a failed query, since both return empty. Without `revalidate`, Next pins `s-maxage=31536000` on the resulting 404, so a momentary upstream failure takes a live post offline for a year.

The #383 preview deploy hit exactly this: four of six posts still 404 at the edge despite rendering correctly at the source, because they were requested during the window before the persisted query registered.

Adding `revalidate` to the 404 branch does not prevent a bad 404, it caps it at five minutes.

## AI usage

Model(s): claude-opus-5
Used for: Root cause investigation, drafting, and implementation